### PR TITLE
Fix Missing directory when pulling on slicer

### DIFF
--- a/PRISMRendering/CMakeLists.txt
+++ b/PRISMRendering/CMakeLists.txt
@@ -21,6 +21,8 @@ set(MODULE_PYTHON_SCRIPTS
   PRISMRenderingParams/TransferFunctionParam.py
   PRISMRenderingParams/RangeParam.py
   PRISMRenderingParams/FourFParam.py
+  PRISMRenderingPoints/__init__.py
+  PRISMRenderingPoints/CustomShaderPoints.py
   PRISMRenderingVolumes/__init__.py
   PRISMRenderingVolumes/PRISMRenderingVolume.py
   )


### PR DESCRIPTION
When we download from 3D Slicer PRISM, PRISMRenderingPoints is missing because it wasn't added in the CMakeList